### PR TITLE
[#188143766] Remove unnecessary sso redirect for /userinfo endpoint

### DIFF
--- a/local-development/spring-enterprise/routes.yml
+++ b/local-development/spring-enterprise/routes.yml
@@ -146,7 +146,6 @@ spring:
           filters:
             - RedirectTo=302, /whoami
             - SetResponseHeader=Cache-Control, no-store
-            - SsoLogin
             - TokenRelay
           tags:
             - users
@@ -164,7 +163,6 @@ spring:
           filters:
             - StripPrefix=0
             - TokenRelay
-            - SsoLogin
           tags:
             - users
 


### PR DESCRIPTION
Addresses a CORS error when running the app locally and user is not logged in